### PR TITLE
Fix resume after activity in background, cancel subscription when the Activity is destroyed

### DIFF
--- a/app/src/main/java/com/morihacky/android/rxjava/RotationPersistFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/RotationPersistFragment.java
@@ -108,7 +108,6 @@ public class RotationPersistFragment
                   }
               }));
 
-        intsObservable.connect();
     }
 
     // -----------------------------------------------------------------------------------

--- a/app/src/main/java/com/morihacky/android/rxjava/RotationPersistWorkerFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/RotationPersistWorkerFragment.java
@@ -6,6 +6,7 @@ import android.support.v4.app.Fragment;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import rx.Observable;
+import rx.Subscription;
 import rx.functions.Func1;
 import rx.observables.ConnectableObservable;
 
@@ -14,6 +15,7 @@ public class RotationPersistWorkerFragment
 
     private ConnectableObservable<Integer> storedIntsObservable;
     private IAmYourMaster _masterFrag;
+    private Subscription storedIntsSubscription;
 
     /**
      * Hold a reference to the activity -> caller fragment
@@ -66,6 +68,8 @@ public class RotationPersistWorkerFragment
         //_intsObservable = _intsObservable.share();
         storedIntsObservable = intsObservable.replay();
 
+        storedIntsSubscription = storedIntsObservable.connect();
+
         // Do not do this in production!
         // `.share` is "warm" not "hot"
         // the below forceful subscription fakes the heat
@@ -89,6 +93,11 @@ public class RotationPersistWorkerFragment
     public void onDetach() {
         super.onDetach();
         _masterFrag = null;
+    }
+
+    @Override public void onDestroy() {
+        super.onDestroy();
+        storedIntsSubscription.unsubscribe();
     }
 
     public interface IAmYourMaster {

--- a/app/src/main/java/com/morihacky/android/rxjava/RotationPersistWorkerFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/RotationPersistWorkerFragment.java
@@ -76,8 +76,8 @@ public class RotationPersistWorkerFragment
      * The Worker fragment has started doing it's thing
      */
     @Override
-    public void onStart() {
-        super.onStart();
+    public void onResume() {
+        super.onResume();
         _masterFrag.observeResults(storedIntsObservable);
     }
 


### PR DESCRIPTION
Just a couple of fixes:
 - resume after activity in background: onStart -> onResume in RotationPersistFragment
 - store subscription in RotationPersistFragment to unsubscribe when the Activity is "really" destroyed