### PR TITLE
fix: Shadow subscriptions not been unsubscribed.

### DIFF
--- a/app/src/main/java/com/morihacky/android/rxjava/fragments/ConcurrencyWithSchedulersDemoFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/fragments/ConcurrencyWithSchedulersDemoFragment.java
@@ -39,12 +39,6 @@ public class ConcurrencyWithSchedulersDemoFragment
     private List<String> _logs;
     private Subscription _subscription;
 
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        ButterKnife.unbind(this);
-        RxUtils.unsubscribeIfNotNull(_subscription);
-    }
 
     @Override
     public void onActivityCreated(@Nullable Bundle savedInstanceState) {
@@ -61,9 +55,22 @@ public class ConcurrencyWithSchedulersDemoFragment
         return layout;
     }
 
+    @Override
+    public void onPause() {
+        super.onPause();
+        RxUtils.unsubscribeIfNotNull(_subscription);
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        ButterKnife.unbind(this);
+    }
+
     @OnClick(R.id.btn_start_operation)
     public void startLongOperation() {
 
+        RxUtils.unsubscribeIfNotNull(_subscription);
         _progress.setVisibility(View.VISIBLE);
         _log("Button Clicked");
 


### PR DESCRIPTION
UnSubscribing the subscription on every click fixes the crash case reported in #65. The other approaches would be to use the `CompositeSubscription`, or RxBinding and debounce the clicks while the operation is running.