### PR TITLE
PseudoCacheMergeFragment: onNext now only adds the next 'contributor'…

### DIFF
--- a/app/src/main/java/com/morihacky/android/rxjava/fragments/PseudoCacheMergeFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/fragments/PseudoCacheMergeFragment.java
@@ -86,21 +86,10 @@ public class PseudoCacheMergeFragment
                       _contributionMap.put(contributor.login, contributor.contributions);
                       _resultAgeMap.put(contributor, contributorAgePair.second);
 
-                      _adapter.clear();
-                      _adapter.addAll(getListStringFromMap());
+                      String rowLog = String.format("%s [%d]", contributor.login, contributor.contributions);
+                      _adapter.add(rowLog);
                   }
               });
-    }
-
-    private List<String> getListStringFromMap() {
-        List<String> list = new ArrayList<>();
-
-        for (String username : _contributionMap.keySet()) {
-            String rowLog = String.format("%s [%d]", username, _contributionMap.get(username));
-            list.add(rowLog);
-        }
-
-        return list;
     }
 
     private Observable<Pair<Contributor, Long>> _getCachedData() {


### PR DESCRIPTION
CashMergeFragment only adds the next contributor at a time instead of clearing & updating entire adapter for each next contributor.