### PR TITLE
Fix for #94 "GUI elements must not be accessed from non-main threads"

### DIFF
--- a/app/src/main/java/com/morihacky/android/rxjava/fragments/DebounceSearchEmitterFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/fragments/DebounceSearchEmitterFragment.java
@@ -73,7 +73,7 @@ public class DebounceSearchEmitterFragment
 
         _disposable = RxJavaInterop.toV2Observable(RxTextView.textChangeEvents(_inputSearchText))
               .debounce(400, TimeUnit.MILLISECONDS)// default Scheduler is Computation
-              .filter(changes -> isNotNullOrEmpty(_inputSearchText.getText().toString()))
+              .filter(changes -> isNotNullOrEmpty(changes.text().toString()))
               .observeOn(AndroidSchedulers.mainThread())
               .subscribeWith(_getSearchObserver());
     }


### PR DESCRIPTION
Now the EditText _inputSearchText is not accessed anymore from a non-UI thread by the filter() operator: instead we use the text-change event.

This fixes #94