### PR TITLE
Add link for Exponential Backoff with Jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ We simulate this behaviour using RxJava with the [`retryWhen` operator](http://r
 
 * http://stackoverflow.com/a/25292833/159825
 * Another excellent implementation via @[sddamico](https://github.com/sddamico) : https://gist.github.com/sddamico/c45d7cdabc41e663bea1
+* This one includes support for jittering, by @[leandrofavarin](https://github.com/leandrofavarin) : http://leandrofavarin.com/exponential-backoff-rxjava-operator-with-jitter
 
 Also look at the [Polling example](https://github.com/kaushikgopal/RxJava-Android-Samples#polling-with-schedulers) where we use a very similar Exponential backoff mechanism.
 


### PR DESCRIPTION
After reading [this article](https://stripe.com/blog/idempotency) about how Stripe handle errors between the clients and the server, I learned about the [Thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem), and I decided to write one operator in Java using RxJava 2, including support for the Jitter.

This PR adds a link to the post I wrote.

Hopefully it'll be useful for anyone interested!