### PR TITLE
fix: Forbid the addition of 0 to 9 items

### DIFF
--- a/app/src/main/java/com/morihacky/android/rxjava/pagination/PaginationAutoFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/pagination/PaginationAutoFragment.java
@@ -8,20 +8,23 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ProgressBar;
-import butterknife.BindView;
-import butterknife.ButterKnife;
+
 import com.morihacky.android.rxjava.MainActivity;
 import com.morihacky.android.rxjava.R;
 import com.morihacky.android.rxjava.fragments.BaseFragment;
 import com.morihacky.android.rxjava.rxbus.RxBus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
 import io.reactivex.Flowable;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.disposables.Disposable;
 import io.reactivex.processors.PublishProcessor;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 public class PaginationAutoFragment extends BaseFragment {
 
@@ -109,7 +112,7 @@ public class PaginationAutoFragment extends BaseFragment {
     _disposables.add(d1);
     _disposables.add(d2);
 
-    _paginator.onNext(0);
+    _paginator.onNext(_adapter.getItemCount());
   }
 
   @Override


### PR DESCRIPTION
If you turn the screen off during pagination and turn it on for a while, the item is added from 0 to 9.
Like this, 

> Item 0
Item 1
Item 3
Item 4
Item 5
Item 6
Item 7
Item 8
Item 9
Item 0
Item 1
Item 2
Item 3
Item 4
Item 5
Item 6
Item 7
Item 8
Item 9
Item 20
Item 21
Item 22
Item 23
Item 24
Item 25
Item 26
Item 27
Item 28
Item 29

The reason is that `_paginator.onNext(0)` is called in `onStart` when the screen is on.
If emit the number of the list in `onStart`, it display normally.

