### PR TITLE
Corrected method name typo

### DIFF
--- a/app/src/main/java/com/morihacky/android/rxjava/fragments/TimingDemoFragment.java
+++ b/app/src/main/java/com/morihacky/android/rxjava/fragments/TimingDemoFragment.java
@@ -173,7 +173,7 @@ public class TimingDemoFragment extends BaseFragment {
   }
 
   @OnClick(R.id.btn_demo_timing_5)
-  public void btn5_RunTask5Times_IntervalOf3s() {
+  public void btn5_RunTaskA_Pause_ThenRunTaskB() {
     _log(String.format("D5 [%s] --- BTN click", _getCurrentTimestamp()));
 
     Flowable.just("Do task A right away")


### PR DESCRIPTION
A small fix of method name typo.

_from_ -> `btn5_RunTask5Times_IntervalOf3s()`
_to_ -> `btn5_RunTaskA_Pause_ThenRunTaskB()`
> As btn4 has the same name as `btn4_RunTask5Times_IntervalOf3s()`